### PR TITLE
Encoding issue

### DIFF
--- a/nltkrest/nltkrest/server.py
+++ b/nltkrest/nltkrest/server.py
@@ -61,7 +61,7 @@ def namedEntityRecognizer():
         echo2("Incoming content is "+content)
     start = time.time()
     date_time = timex.tag(content)
-    tokenized = nltk.word_tokenize(content)
+    tokenized = nltk.word_tokenize(content.decode("utf-8"))
     tagged = nltk.pos_tag(tokenized)
     namedEnt = nltk.ne_chunk(tagged, binary=True)
     names = extract_entity_names(namedEnt, 'NE')


### PR DESCRIPTION
@chrismattmann please review this change. 

Since we do not know the encoding of all text passed to NLTK, this allows us to explicitly decode any utf-8 stream (or ascii ) and create their tokens. 

We can use [https://pypi.python.org/pypi/chardet|chardet library] from pypi, but thats a slow process to detect the encoding type for each stream. Instead before a stream is passed, it must be made sure that it is converted to utf-8 encoding. 
